### PR TITLE
Handling Left Key Presses for Transition from Paragraph to Page Title

### DIFF
--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -544,6 +544,16 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
   handleUnknownBlockBackspace(model);
 }
 
+function handleParagraphBlockLeftKey(page: Page, model: ExtendedModel) {
+  if (!matchFlavours(model, ['affine:paragraph'])) return false;
+  console.log('works');
+  return true;
+}
+
+export function handleLineStartLeftKey(page: Page, model: ExtendedModel) {
+  handleParagraphBlockLeftKey(page, model);
+}
+
 export function handleKeyUp(event: KeyboardEvent, editableContainer: Element) {
   const range = getCurrentNativeRange();
   if (!range.collapsed) {

--- a/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
+++ b/packages/blocks/src/__internal__/rich-text/rich-text-operations.ts
@@ -5,6 +5,7 @@ import type { BlockModelProps } from '@blocksuite/global/types';
 import { assertExists, matchFlavours } from '@blocksuite/global/utils';
 import type { BaseBlockModel, Page } from '@blocksuite/store';
 import { Text, Utils } from '@blocksuite/store';
+import { match } from 'assert';
 
 import type { PageBlockModel } from '../../models.js';
 import { checkFirstLine, checkLastLine } from '../utils/check-line.js';
@@ -546,7 +547,12 @@ export function handleLineStartBackspace(page: Page, model: ExtendedModel) {
 
 function handleParagraphBlockLeftKey(page: Page, model: ExtendedModel) {
   if (!matchFlavours(model, ['affine:paragraph'])) return false;
-  console.log('works');
+  const previousBlockFlavour = getPreviousBlock(model)?.flavour;
+  if (previousBlockFlavour == 'affine:surface') {
+    console.log('works');
+    return PREVENT_DEFAULT;
+  }
+  ALLOW_DEFAULT;
   return true;
 }
 

--- a/packages/blocks/src/__internal__/service/index.ts
+++ b/packages/blocks/src/__internal__/service/index.ts
@@ -236,7 +236,12 @@ export class BaseService<BlockModel extends BaseBlockModel = BaseBlockModel> {
         key: 'ArrowLeft',
         shiftKey: false,
         handler(range, context) {
-          return onKeyLeft(context.event, range);
+          return onKeyLeft(
+            block,
+            context.event,
+            range,
+            this.vEditor.rootElement
+          );
         },
       },
       right: {

--- a/packages/blocks/src/__internal__/service/keymap.ts
+++ b/packages/blocks/src/__internal__/service/keymap.ts
@@ -12,11 +12,16 @@ import {
   handleBlockEndEnter,
   handleBlockSplit,
   handleLineStartBackspace,
+  handleLineStartLeftKey,
   handleSoftEnter,
   handleUnindent,
 } from '../rich-text/rich-text-operations.js';
 import type { AffineVEditor } from '../rich-text/virgo/types.js';
-import { isCollapsedAtBlockStart } from '../utils/index.js';
+import { checkFirstLine } from '../utils/check-line.js';
+import {
+  getCurrentNativeRange,
+  isCollapsedAtBlockStart,
+} from '../utils/index.js';
 
 export function onSoftEnter(
   model: BaseBlockModel,
@@ -177,7 +182,12 @@ export function onBackspace(
   return ALLOW_DEFAULT;
 }
 
-export function onKeyLeft(e: KeyboardEvent, range: VRange) {
+export function onKeyLeft(
+  model: BaseBlockModel,
+  e: KeyboardEvent,
+  range: VRange,
+  editableContainer: Element
+) {
   // range.length === 0 means collapsed selection
   if (range.length !== 0) {
     e.stopPropagation();
@@ -187,6 +197,11 @@ export function onKeyLeft(e: KeyboardEvent, range: VRange) {
   if (!lineStart) {
     e.stopPropagation();
     return ALLOW_DEFAULT;
+  }
+  const nativeRange = getCurrentNativeRange();
+  const isFirstLine = checkFirstLine(nativeRange, editableContainer);
+  if (isFirstLine && lineStart) {
+    handleLineStartLeftKey(model.page, model);
   }
   // Need jump to previous block
   return PREVENT_DEFAULT;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 patchedDependencies:
   hotkeys-js@3.10.1:
@@ -147,12 +151,12 @@ importers:
       hotkeys-js:
         specifier: ^3.10.1
         version: 3.10.1(patch_hash=otx73r74oyscqvo3amwccrzngy)
-      jszip:
-        specifier: ^3.10.1
-        version: 3.10.1
       html-to-image:
         specifier: ^1.11.11
         version: 1.11.11
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lit:
         specifier: ^2.7.3
         version: 2.7.3


### PR DESCRIPTION
This pull request involves modifications in the keymap and rich-text-operations files with the aim of refining the handling of Left Key presses.

The main objective behind this implementation is to allow the cursor to move to the Page Title when the Left Key is pressed at the start of the first Paragraph block. To accomplish this, the handlers are set to return PREVENT_DEFAULT when the preceding block is affine:surface, intending to emulate the typical navigation observed in rich text editing interfaces.

However, the current implementation does not yield the expected results - pressing the Left Key at the beginning of the first Paragraph block does not relocate the cursor to the Page Title.

Even though at the handleKeyDown you can transition from Page Title to Paragraph for example doing it like that.


I welcome any insights or advice regarding why this might be occurring, and what potential solutions could resolve this issue. Your expertise would be highly valuable in addressing this, thereby improving the overall user experience in our text interface.

Thank you in advance for your assistance and dedication to enhancing our project.